### PR TITLE
Changes for exceptions-0.4.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 cabal.sandbox.config
 src/Test.hs
 src-old
+.cabal-sandbox

--- a/oauthenticated.cabal
+++ b/oauthenticated.cabal
@@ -1,5 +1,5 @@
 name:                oauthenticated
-version:             0.1.2
+version:             0.1.3
 synopsis:            Simple OAuth for http-client
 
 description:         
@@ -60,7 +60,7 @@ library
                      , crypto-random       >= 0.0.7
                      , cryptohash          >= 0.11     && < 0.12
                      , either              >= 4.0      && < 5.0
-                     , exceptions          >= 0.3      && < 0.4
+                     , exceptions          >= 0.4
                      , http-client         >= 0.2.0
                      , http-types          >= 0.8
                      , mtl                 >= 2.0

--- a/src/Network/OAuth/Simple.hs
+++ b/src/Network/OAuth/Simple.hs
@@ -86,6 +86,7 @@ newtype OAuthT ty m a =
            , MonadReader (OaConfig ty)
            , MonadState R.SystemRNG
            , E.MonadCatch
+           , E.MonadThrow
            , MonadIO
            )
 instance MonadTrans (OAuthT ty) where lift = OAuthT . lift . lift


### PR DESCRIPTION
Changes to compile with exceptions-0.4 which has separated out a new "MonadThrow" class from "MonadCatch".
