### PR TITLE
don't sign body when not form-urlencoded

### DIFF
--- a/src/Network/OAuth/Signing.hs
+++ b/src/Network/OAuth/Signing.hs
@@ -124,9 +124,13 @@ canonicalParams oax server req =
 
       combine :: [S.ByteString] -> S.ByteString
       combine = pctEncode . S8.intercalate "&"
+
+      reqIsFormUrlEncoded = case lookup H.hContentType (C.requestHeaders req) of
+                              Just "application/x-www-form-urlencoded" -> True
+                              _                                        -> False
   in combine . sort . map build . mconcat
      $ [ oauthParams oax server
-       , bodyParams req
+       , if reqIsFormUrlEncoded then bodyParams req else []
        , queryParams req
        ]
 


### PR DESCRIPTION
see issue #4.

note: this is only tested for one oauth endpoint!
