### PR TITLE
add network-uri flag

### DIFF
--- a/oauthenticated.cabal
+++ b/oauthenticated.cabal
@@ -69,7 +69,7 @@ library
                      , http-types          >= 0.8
                      , mtl                 >= 2.0
                      , time                >= 1.2
-                     , text                >= 0.11     && < 1.2
+                     , text                >= 0.11     && < 1.3
                      , transformers
 
   if flag(network-uri)


### PR DESCRIPTION
this is a possible fix for issue #13.

Drawbacks are, that it depends on `network` even though it does not use it. I don't know any other way to specify conflicts though (because it would be cleaner to just specify `conflicts: network < 2.6`).
