### PR TITLE
RFC: use MonadRandom

### DIFF
--- a/oauthenticated.cabal
+++ b/oauthenticated.cabal
@@ -1,5 +1,5 @@
 name:                oauthenticated
-version:             0.1.3.4
+version:             0.2.0
 synopsis:            Simple OAuth for http-client
 
 description:         
@@ -57,16 +57,15 @@ library
     Network.OAuth.Util
   build-depends:       base                >= 4.6      && < 4.9
                      , aeson               >= 0.6.2    && < 0.10
-                     , base64-bytestring   >= 1.0      && < 1.1
                      , blaze-builder       >= 0.3
                      , bytestring          >= 0.9
                      , case-insensitive    >= 1.0      && < 1.3
-                     , crypto-random       >= 0.0.7
-                     , cryptohash          >= 0.11     && < 0.12
+                     , cryptonite          == 0.2.*
                      , either              >= 4.0      && < 5.0
                      , exceptions          >= 0.4
                      , http-client         >= 0.2.0
                      , http-types          >= 0.8
+                     , memory              >= 0.7
                      , mtl                 >= 2.0
                      , time                >= 1.2
                      , text                >= 0.11     && < 1.3

--- a/src/Network/OAuth.hs
+++ b/src/Network/OAuth.hs
@@ -38,14 +38,14 @@ module Network.OAuth (
   -- a fresh set of 'O.Oa' parameters from a relevant or deterministic
   -- 'O.OaPin' and then using 'S.sign' to sign the 'C.Request'.
   S.sign,
-  
+
   -- ** Generating OAuth parameters
-  O.emptyOa, O.freshOa, O.emptyPin, O.freshPin, 
+  O.emptyOa, O.freshOa, O.emptyPin, O.freshPin,
 
   -- * OAuth Credentials
   O.Token (..), O.Cred, O.Client, O.Temporary, O.Permanent,
 
-  -- ** Creating Credentials  
+  -- ** Creating Credentials
   O.clientCred, O.temporaryCred, O.permanentCred,
   O.fromUrlEncoded,
 

--- a/src/Network/OAuth.hs
+++ b/src/Network/OAuth.hs
@@ -62,11 +62,11 @@ import qualified Network.OAuth.Types.Credentials as O
 import qualified Network.OAuth.Types.Params      as O
 
 -- | Sign a request with a fresh set of parameters. Creates a fresh
--- 'R.SystemRNG' using new entropy for each signing and thus is potentially
+-- 'R.ChaChaDRG' using new entropy for each signing and thus is potentially
 -- /dangerous/ if used too frequently. In almost all cases, 'S.oauth'
 -- should be used instead.
 oauthSimple :: O.Cred ty -> O.Server -> C.Request -> IO C.Request
 oauthSimple cr srv req = do
-  entropy   <- R.createEntropyPool
-  (req', _) <- S.oauth cr srv req (R.cprgCreate entropy :: R.SystemRNG)
+  entropy   <- R.drgNew
+  (req', _) <- S.oauth cr srv req entropy
   return req'

--- a/src/Network/OAuth.hs
+++ b/src/Network/OAuth.hs
@@ -29,7 +29,7 @@ module Network.OAuth (
   -- function should be used which allows for threading of the random
   -- source.
   --
-  oauthSimple, S.oauth,
+  S.oauth,
 
   -- * Lower-level and pure functionality
   --
@@ -55,18 +55,6 @@ module Network.OAuth (
 
   ) where
 
-import qualified Crypto.Random                   as R
-import qualified Network.HTTP.Client             as C
 import qualified Network.OAuth.Signing           as S
 import qualified Network.OAuth.Types.Credentials as O
 import qualified Network.OAuth.Types.Params      as O
-
--- | Sign a request with a fresh set of parameters. Creates a fresh
--- 'R.ChaChaDRG' using new entropy for each signing and thus is potentially
--- /dangerous/ if used too frequently. In almost all cases, 'S.oauth'
--- should be used instead.
-oauthSimple :: O.Cred ty -> O.Server -> C.Request -> IO C.Request
-oauthSimple cr srv req = do
-  entropy   <- R.drgNew
-  (req', _) <- S.oauth cr srv req entropy
-  return req'

--- a/src/Network/OAuth/MuLens.hs
+++ b/src/Network/OAuth/MuLens.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes            #-}
 
@@ -21,7 +22,14 @@ module Network.OAuth.MuLens (
   (<&>), (&), (^.), (.~), (%~),
   ) where
 
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
+
+#if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative
+#endif
+
 import           Data.Functor.Identity
 import           Data.Functor.Constant
 

--- a/src/Network/OAuth/Signing.hs
+++ b/src/Network/OAuth/Signing.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TupleSections     #-}
@@ -35,7 +36,14 @@ module Network.OAuth.Signing (
 
   ) where
 
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
+
+#if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative
+#endif
+
 import qualified Blaze.ByteString.Builder        as Blz
 import           Crypto.Hash                     (SHA1)
 import           Crypto.MAC.HMAC                 (HMAC, hmac)

--- a/src/Network/OAuth/Signing.hs
+++ b/src/Network/OAuth/Signing.hs
@@ -45,6 +45,7 @@ import           Control.Applicative
 #endif
 
 import qualified Blaze.ByteString.Builder        as Blz
+import           Control.Monad.IO.Class                  (MonadIO)
 import           Crypto.Hash                     (SHA1)
 import           Crypto.MAC.HMAC                 (HMAC, hmac)
 import           Crypto.Random
@@ -66,10 +67,10 @@ import           Network.OAuth.Util
 import           Network.URI
 
 -- | Sign a request with a fresh set of parameters.
-oauth :: DRG gen => Cred ty -> Server -> C.Request -> gen -> IO (C.Request, gen)
-oauth creds sv req gen = do
-  (oax, gen') <- freshOa creds gen
-  return (sign oax sv req, gen')
+oauth :: (MonadIO io, MonadRandom io) => Cred ty -> Server -> C.Request -> io C.Request
+oauth creds sv req = do
+  oax <- freshOa creds
+  return (sign oax sv req)
 
 -- | Sign a request given generated parameters
 sign :: Oa ty -> Server -> C.Request -> C.Request

--- a/src/Network/OAuth/Simple.hs
+++ b/src/Network/OAuth/Simple.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 -- |
@@ -59,7 +60,14 @@ module Network.OAuth.Simple (
 
   ) where
 
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
+
+#if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative
+#endif
+
 import qualified Control.Monad.Catch             as E
 import           Control.Monad.Reader
 import           Control.Monad.State

--- a/src/Network/OAuth/Simple.hs
+++ b/src/Network/OAuth/Simple.hs
@@ -70,7 +70,6 @@ import           Control.Applicative
 
 import qualified Control.Monad.Catch             as E
 import           Control.Monad.Reader
-import           Control.Monad.State
 import           Control.Monad.Trans.Either
 import qualified Crypto.Random                   as R
 import qualified Data.ByteString.Lazy            as SL
@@ -89,15 +88,14 @@ data OaConfig ty =
 -- | Perform authenticated requests using a shared 'C.Manager' and
 -- a particular set of 'O.Cred's.
 newtype OAuthT ty m a =
-  OAuthT { unOAuthT :: ReaderT (OaConfig ty) (StateT R.ChaChaDRG m) a }
+  OAuthT { unOAuthT :: ReaderT (OaConfig ty) m a }
   deriving ( Functor, Applicative, Monad
            , MonadReader (OaConfig ty)
-           , MonadState R.ChaChaDRG
            , E.MonadCatch
            , E.MonadThrow
            , MonadIO
            )
-instance MonadTrans (OAuthT ty) where lift = OAuthT . lift . lift
+instance MonadTrans (OAuthT ty) where lift = OAuthT . lift
 
 -- | 'OAuthT' wrapped over 'IO'.
 type OAuth ty = OAuthT ty IO
@@ -107,9 +105,8 @@ runOAuthT
   :: (MonadIO m) =>
      OAuthT ty m a -> O.Cred ty -> O.Server -> O.ThreeLegged ->
      m a
-runOAuthT oat cr srv tl = do
-  gen <- liftIO R.drgNew
-  evalStateT (runReaderT (unOAuthT oat) (OaConfig cr srv tl)) gen
+runOAuthT oat cr srv tl =
+  runReaderT (unOAuthT oat) (OaConfig cr srv tl)
 
 runOAuth :: OAuth ty a -> O.Cred ty -> O.Server -> O.ThreeLegged -> IO a
 runOAuth = runOAuthT
@@ -129,24 +126,18 @@ upgradeCred tok = liftM (Cred.upgradeCred tok . cred) ask
 
 -- | Given a 'Cred.ResourceToken' of some kind, run an inner 'OAuthT' session
 -- with the same configuration but new credentials.
-upgrade :: (Cred.ResourceToken ty', Monad m, MonadIO m) => O.Token ty' -> OAuthT ty' m a -> OAuthT ty m a
+upgrade :: (Cred.ResourceToken ty', Monad m, MonadIO m, R.MonadRandom m) => O.Token ty' -> OAuthT ty' m a -> OAuthT ty m a
 upgrade tok oat = do
-  gen  <- liftIO R.drgNew
   conf <- ask
   let conf' = conf { cred = Cred.upgradeCred tok (cred conf) }
-  lift $ evalStateT (runReaderT (unOAuthT oat) conf') gen
+  lift $ runReaderT (unOAuthT oat) conf'
 
-liftBasic :: MonadIO m => (R.ChaChaDRG -> OaConfig ty -> IO (a, R.ChaChaDRG)) -> OAuthT ty m a
-liftBasic f = do
-  gen  <- get
-  conf <- ask
-  (a, gen') <- liftIO (f gen conf)
-  put gen'
-  return a
+liftBasic :: MonadIO m => (OaConfig ty -> IO a) -> OAuthT ty m a
+liftBasic f = ask >>= liftIO . f
 
 -- | Sign a request using fresh credentials.
 oauth :: MonadIO m => C.Request -> OAuthT ty m C.Request
-oauth req = liftBasic $ \gen conf -> O.oauth (cred conf) (server conf) req gen
+oauth req = liftBasic $ \conf -> O.oauth (cred conf) (server conf) req
 
 -- Three-Legged Authorization
 --------------------------------------------------------------------------------
@@ -155,12 +146,11 @@ requestTemporaryToken
   :: MonadIO m => C.Manager ->
      OAuthT O.Client m (C.Response (Either SL.ByteString (O.Token O.Temporary)))
 requestTemporaryToken man =
-  liftBasic $ \gen conf ->
+  liftBasic $ \conf ->
     O.requestTemporaryToken (cred conf)
                             (server conf)
                             (threeLegged conf)
                             man
-                            gen
 
 buildAuthorizationUrl :: Monad m => OAuthT O.Temporary m URI
 buildAuthorizationUrl = do
@@ -171,13 +161,12 @@ requestPermanentToken
   :: MonadIO m => C.Manager -> O.Verifier ->
      OAuthT O.Temporary m (C.Response (Either SL.ByteString (O.Token O.Permanent)))
 requestPermanentToken man ver =
-  liftBasic $ \gen conf ->
+  liftBasic $ \conf ->
     O.requestPermanentToken (cred conf)
                             (server conf)
                             ver
                             (threeLegged conf)
                             man
-                            gen
 
 data TokenRequestFailure =
     OnTemporaryRequest C.HttpException
@@ -191,7 +180,7 @@ data TokenRequestFailure =
 -- "Network.OAuth.ThreeLegged", but offers better error handling due in part to
 -- the easier management of configuration state.
 requestTokenProtocol
-  :: (Functor m, MonadIO m, E.MonadCatch m) =>
+  :: (Functor m, MonadIO m, R.MonadRandom m, E.MonadCatch m) =>
      C.Manager -> (URI -> m O.Verifier) ->
      OAuthT O.Client m (Either TokenRequestFailure (O.Cred O.Permanent))
 requestTokenProtocol man getVerifier = runEitherT $ do
@@ -216,7 +205,7 @@ requestTokenProtocol man getVerifier = runEitherT $ do
     upE      :: (Monad m, Functor m) => (e -> f) -> Either e b -> EitherT f m b
     upE f = liftE f . return
     -- This is just 'upgrade' played out in the EitherT monad.
-    upgradeE :: (Monad m, MonadIO m, Cred.ResourceToken ty') =>
+    upgradeE :: (Monad m, MonadIO m, R.MonadRandom m, Cred.ResourceToken ty') =>
                 Cred.Token ty'
                 -> EitherT e (OAuthT ty' m) a -> EitherT e (OAuthT ty m) a
     upgradeE tok = EitherT . upgrade tok . runEitherT

--- a/src/Network/OAuth/Simple.hs
+++ b/src/Network/OAuth/Simple.hs
@@ -81,10 +81,10 @@ data OaConfig ty =
 -- | Perform authenticated requests using a shared 'C.Manager' and
 -- a particular set of 'O.Cred's.
 newtype OAuthT ty m a =
-  OAuthT { unOAuthT :: ReaderT (OaConfig ty) (StateT R.SystemRNG m) a }
+  OAuthT { unOAuthT :: ReaderT (OaConfig ty) (StateT R.ChaChaDRG m) a }
   deriving ( Functor, Applicative, Monad
            , MonadReader (OaConfig ty)
-           , MonadState R.SystemRNG
+           , MonadState R.ChaChaDRG
            , E.MonadCatch
            , E.MonadThrow
            , MonadIO
@@ -100,8 +100,8 @@ runOAuthT
      OAuthT ty m a -> O.Cred ty -> O.Server -> O.ThreeLegged ->
      m a
 runOAuthT oat cr srv tl = do
-  entropy <- liftIO R.createEntropyPool
-  evalStateT (runReaderT (unOAuthT oat) (OaConfig cr srv tl)) (R.cprgCreate entropy)
+  gen <- liftIO R.drgNew
+  evalStateT (runReaderT (unOAuthT oat) (OaConfig cr srv tl)) gen
 
 runOAuth :: OAuth ty a -> O.Cred ty -> O.Server -> O.ThreeLegged -> IO a
 runOAuth = runOAuthT
@@ -121,14 +121,14 @@ upgradeCred tok = liftM (Cred.upgradeCred tok . cred) ask
 
 -- | Given a 'Cred.ResourceToken' of some kind, run an inner 'OAuthT' session
 -- with the same configuration but new credentials.
-upgrade :: (Cred.ResourceToken ty', Monad m) => O.Token ty' -> OAuthT ty' m a -> OAuthT ty m a
+upgrade :: (Cred.ResourceToken ty', Monad m, MonadIO m) => O.Token ty' -> OAuthT ty' m a -> OAuthT ty m a
 upgrade tok oat = do
-  gen  <- state R.cprgFork
+  gen  <- liftIO R.drgNew
   conf <- ask
   let conf' = conf { cred = Cred.upgradeCred tok (cred conf) }
   lift $ evalStateT (runReaderT (unOAuthT oat) conf') gen
 
-liftBasic :: MonadIO m => (R.SystemRNG -> OaConfig ty -> IO (a, R.SystemRNG)) -> OAuthT ty m a
+liftBasic :: MonadIO m => (R.ChaChaDRG -> OaConfig ty -> IO (a, R.ChaChaDRG)) -> OAuthT ty m a
 liftBasic f = do
   gen  <- get
   conf <- ask
@@ -208,7 +208,7 @@ requestTokenProtocol man getVerifier = runEitherT $ do
     upE      :: (Monad m, Functor m) => (e -> f) -> Either e b -> EitherT f m b
     upE f = liftE f . return
     -- This is just 'upgrade' played out in the EitherT monad.
-    upgradeE :: (Monad m, Cred.ResourceToken ty') =>
+    upgradeE :: (Monad m, MonadIO m, Cred.ResourceToken ty') =>
                 Cred.Token ty'
                 -> EitherT e (OAuthT ty' m) a -> EitherT e (OAuthT ty m) a
     upgradeE tok = EitherT . upgrade tok . runEitherT

--- a/src/Network/OAuth/Simple.hs
+++ b/src/Network/OAuth/Simple.hs
@@ -195,7 +195,7 @@ requestTokenProtocol man getVerifier = runEitherT $ do
   upgradeE ttok $ do
     verifier <- lift $ buildAuthorizationUrl >>= lift . getVerifier
     permResp <- liftE OnPermanentRequest $ E.try (requestPermanentToken man verifier)
-    ptok     <- upE BadPermanentToken $ C.responseBody permResp 
+    ptok     <- upE BadPermanentToken $ C.responseBody permResp
     lift $ upgradeCred ptok
   where
     -- These functions explain most of the EitherT noise. They're largely

--- a/src/Network/OAuth/ThreeLegged.hs
+++ b/src/Network/OAuth/ThreeLegged.hs
@@ -189,9 +189,9 @@ requestTokenProtocol' mset cr srv tl getVerifier = do
 -- will throw a 'C.TlsNotSupported' exception if TLS is required.
 --
 -- Throws 'C.HttpException's.
-requestTokenProtocol 
-  :: O.Cred O.Client -> O.Server -> ThreeLegged 
-     -> (URI -> IO P.Verifier) 
+requestTokenProtocol
+  :: O.Cred O.Client -> O.Server -> ThreeLegged
+     -> (URI -> IO P.Verifier)
      -> IO (Maybe (O.Cred O.Permanent))
 requestTokenProtocol = requestTokenProtocol' C.defaultManagerSettings
 

--- a/src/Network/OAuth/ThreeLegged.hs
+++ b/src/Network/OAuth/ThreeLegged.hs
@@ -40,6 +40,7 @@ import           Control.Applicative
 #endif
 
 import           Control.Exception               as E
+import           Control.Monad.IO.Class          (MonadIO, liftIO)
 import qualified Crypto.Random                   as R
 import qualified Data.ByteString.Lazy            as SL
 import           Data.Data
@@ -97,14 +98,13 @@ parseThreeLegged a b c d =
 --
 -- Throws 'C.HttpException's.
 requestTemporaryTokenRaw
-  :: R.DRG gen => O.Cred O.Client -> O.Server
-               -> ThreeLegged -> C.Manager -> gen
-               -> IO (C.Response SL.ByteString, gen)
-requestTemporaryTokenRaw cr srv (ThreeLegged {..}) man gen = do
-  (oax, gen') <- O.freshOa cr gen
+  :: (MonadIO io, R.MonadRandom io)
+  => O.Cred O.Client -> O.Server -> ThreeLegged -> C.Manager
+  -> io (C.Response SL.ByteString)
+requestTemporaryTokenRaw cr srv (ThreeLegged {..}) man = do
+  oax <- O.freshOa cr
   let req = O.sign (oax { P.workflow = P.TemporaryTokenRequest callback }) srv temporaryTokenRequest
-  lbs <- C.httpLbs req man
-  return (lbs, gen')
+  liftIO $ C.httpLbs req man
 
 -- | Returns the raw result if the 'C.Response' could not be parsed as
 -- a valid 'O.Token'.  Importantly, in RFC 5849 compliant modes this
@@ -113,12 +113,12 @@ requestTemporaryTokenRaw cr srv (ThreeLegged {..}) man gen = do
 --
 -- Throws 'C.HttpException's.
 requestTemporaryToken
-  :: R.DRG gen => O.Cred O.Client -> O.Server
-               -> ThreeLegged -> C.Manager -> gen
-               -> IO (C.Response (Either SL.ByteString (O.Token O.Temporary)), gen)
-requestTemporaryToken cr srv tl man gen = do
-  (raw, gen') <- requestTemporaryTokenRaw cr srv tl man gen
-  return (tryParseToken <$> raw, gen')
+  :: (MonadIO io, R.MonadRandom io)
+  => O.Cred O.Client -> O.Server -> ThreeLegged -> C.Manager
+  -> io (C.Response (Either SL.ByteString (O.Token O.Temporary)))
+requestTemporaryToken cr srv tl man = do
+  raw <- requestTemporaryTokenRaw cr srv tl man
+  return (tryParseToken <$> raw)
   where
     tryParseToken lbs = case maybeParseToken lbs of
       Nothing  -> Left lbs
@@ -143,28 +143,25 @@ buildAuthorizationUrl cr (ThreeLegged {..}) =
 --
 -- Throws 'C.HttpException's.
 requestPermanentTokenRaw
-  :: R.DRG gen => O.Cred O.Temporary -> O.Server
-               -> P.Verifier
-               -> ThreeLegged -> C.Manager -> gen
-               -> IO (C.Response SL.ByteString, gen)
-requestPermanentTokenRaw cr srv verifier (ThreeLegged {..}) man gen = do
-  (oax, gen') <- O.freshOa cr gen
+  :: (MonadIO io, R.MonadRandom io)
+  => O.Cred O.Temporary -> O.Server -> P.Verifier -> ThreeLegged -> C.Manager
+  -> io (C.Response SL.ByteString)
+requestPermanentTokenRaw cr srv verifier (ThreeLegged {..}) man = do
+  oax <- O.freshOa cr
   let req = O.sign (oax { P.workflow = P.PermanentTokenRequest verifier }) srv permanentTokenRequest
-  lbs <- C.httpLbs req man
-  return (lbs, gen')
+  liftIO $ C.httpLbs req man
 
 -- | Returns 'Nothing' if the response could not be decoded as a 'Token'.
 -- See also 'requestPermanentTokenRaw'.
 --
 -- Throws 'C.HttpException's.
 requestPermanentToken
-  :: R.DRG gen => O.Cred O.Temporary -> O.Server
-               -> P.Verifier
-               -> ThreeLegged -> C.Manager -> gen
-               -> IO (C.Response (Either SL.ByteString (O.Token O.Permanent)), gen)
-requestPermanentToken cr srv verifier tl man gen = do
-  (raw, gen') <- requestPermanentTokenRaw cr srv verifier tl man gen
-  return (tryParseToken <$> raw, gen')
+  :: (MonadIO io, R.MonadRandom io)
+  => O.Cred O.Temporary -> O.Server -> P.Verifier -> ThreeLegged -> C.Manager
+  -> io (C.Response (Either SL.ByteString (O.Token O.Permanent)))
+requestPermanentToken cr srv verifier tl man = do
+  raw <- requestPermanentTokenRaw cr srv verifier tl man
+  return (tryParseToken <$> raw)
   where
     tryParseToken lbs = case maybeParseToken lbs of
       Nothing  -> Left lbs
@@ -177,16 +174,15 @@ requestTokenProtocol'
   :: C.ManagerSettings -> O.Cred O.Client -> O.Server -> ThreeLegged
      -> (URI -> IO P.Verifier)
      -> IO (Maybe (O.Cred O.Permanent))
-requestTokenProtocol' mset cr srv tl getVerifier = do
-  gen <- R.drgNew
+requestTokenProtocol' mset cr srv tl getVerifier =
   E.bracket (C.newManager mset) C.closeManager $ \man -> do
-    (respTempToken, gen') <- requestTemporaryToken cr srv tl man gen
+    respTempToken <- requestTemporaryToken cr srv tl man
     case C.responseBody respTempToken of
       Left _ -> return Nothing
       Right tok -> do
         let tempCr = O.temporaryCred tok cr
         verifier <- getVerifier $ buildAuthorizationUrl tempCr tl
-        (respPermToken, _) <- requestPermanentToken tempCr srv verifier tl man gen'
+        respPermToken <- requestPermanentToken tempCr srv verifier tl man
         case C.responseBody respPermToken of
           Left _ -> return Nothing
           Right tok' -> return (Just $ O.permanentCred tok' cr)

--- a/src/Network/OAuth/ThreeLegged.hs
+++ b/src/Network/OAuth/ThreeLegged.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RecordWildCards    #-}
@@ -30,7 +31,14 @@ module Network.OAuth.ThreeLegged (
   requestTokenProtocol, requestTokenProtocol'
   ) where
 
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
+
+#if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative
+#endif
+
 import           Control.Exception               as E
 import qualified Crypto.Random                   as R
 import qualified Data.ByteString.Lazy            as SL

--- a/src/Network/OAuth/Types/Credentials.hs
+++ b/src/Network/OAuth/Types/Credentials.hs
@@ -110,8 +110,8 @@ instance FromJSON (Token ty) where
 -- | Produces a JSON object using keys named @oauth_token@ and
 -- @oauth_token_secret@.
 instance ToJSON (Token ty) where
-  toJSON (Token k s) = object [ "oauth_token"        .= (decodeLatin1 k)
-                              , "oauth_token_secret" .= (decodeLatin1 s)
+  toJSON (Token k s) = object [ "oauth_token"        .= decodeLatin1 k
+                              , "oauth_token_secret" .= decodeLatin1 s
                               ]
 
 -- | Parses a @www-form-urlencoded@ stream to produce a 'Token' if possible.

--- a/src/Network/OAuth/Types/Params.hs
+++ b/src/Network/OAuth/Types/Params.hs
@@ -21,8 +21,8 @@ module Network.OAuth.Types.Params where
 
 import           Control.Applicative
 import           Crypto.Random
+import           Data.ByteArray.Encoding         (Base(Base64), convertToBase)
 import qualified Data.ByteString                 as S
-import qualified Data.ByteString.Base64          as S64
 import qualified Data.ByteString.Char8           as S8
 import           Data.Data
 import           Data.Time
@@ -178,12 +178,19 @@ emptyPin = OaPin { timestamp = Timestamp (UTCTime (ModifiedJulianDay 0) 0)
 
 -- | Creates a new, unique, unpredictable 'OaPin'. This should be used quickly
 -- as dependent on the OAuth server settings it may expire.
-freshPin :: CPRG gen => gen -> IO (OaPin, gen)
+freshPin :: DRG gen => gen -> IO (OaPin, gen)
 freshPin gen = do
   t <- Timestamp <$> getCurrentTime
   return (OaPin { timestamp = t, nonce = n }, gen')
   where
-    (n, gen') = withRandomBytes gen 8 S64.encode
+    (n, gen') = withRandomBytes gen 8 (convertToBase Base64)
+
+-- | generate @len random bytes and mapped the bytes to the function @f.
+--
+-- This is equivalent to use Control.Arrow 'first' with 'randomBytesGenerate'
+withRandomBytes :: DRG g => g -> Int -> (S.ByteString -> a) -> (a, g)
+withRandomBytes rng len f = (f bs, rng')
+  where (bs, rng') = randomBytesGenerate len rng
 
 -- | Uses 'emptyPin' to create an empty set of params 'Oa'.
 emptyOa :: Cred ty -> Oa ty
@@ -191,7 +198,7 @@ emptyOa creds =
   Oa { credentials = creds, workflow = Standard, pin = emptyPin }
 
 -- | Uses 'freshPin' to create a fresh, default set of params 'Oa'.
-freshOa :: CPRG gen => Cred ty -> gen -> IO (Oa ty, gen)
+freshOa :: DRG gen => Cred ty -> gen -> IO (Oa ty, gen)
 freshOa creds gen = do
   (pinx, gen') <- freshPin gen
   return (Oa { credentials = creds, workflow = Standard, pin = pinx }, gen')

--- a/src/Network/OAuth/Types/Params.hs
+++ b/src/Network/OAuth/Types/Params.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings  #-}
 
@@ -19,7 +20,14 @@
 
 module Network.OAuth.Types.Params where
 
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
+
+#if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative
+#endif
+
 import           Crypto.Random
 import           Data.ByteArray.Encoding         (Base(Base64), convertToBase)
 import qualified Data.ByteString                 as S


### PR DESCRIPTION
See commit b39e1e0 for the meat. It makes a few things way easier. The user will need to supply the `MonadRandom` instance to use though (or stay within `IO` to use `urandom` as before the cryptonite port).