### PR TITLE
Lts upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cabal.sandbox.config
 src/Test.hs
 src-old
 .cabal-sandbox
+.stack-work

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,40 +3,21 @@
 # See https://github.com/hvr/multi-ghc-travis for more information
 
 env:
- - CABALVER=1.16 GHCVER=7.6.3
- - CABALVER=1.18 GHCVER=7.8.4
- - CABALVER=1.22 GHCVER=7.10.1
- - CABALVER=head GHCVER=head
+ - ARGS=""
+ - ARGS="--resolver lts"
+ - ARGS="--resolver nightly"
+ - ARGS="--resolver lts-8"
+ - ARGS="--resolver lts-7"
+ - ARGS="--resolver lts-6"
 
 matrix:
   allow_failures:
-    - env: CABALVER=head GHCVER=head
+    - env: ARGS="--resolver nightly"
 
 before_install:
- - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
- - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
- - export PATH=/opt/ghc/$GHCVER/bin:$HOME/.cabal/bin:/opt/cabal/$CABALVER/bin:$PATH
- - |
-   if [ $GHCVER = "head" ] || [ ${GHCVER%.*} = "7.8" ] || [ ${GHCVER%.*} = "7.10" ]; then
-     travis_retry sudo apt-get install happy-1.19.4 alex-3.1.3
-     export PATH=/opt/alex/3.1.3/bin:/opt/happy/1.19.4/bin:$PATH
-   else
-     travis_retry sudo apt-get install happy alex
-   fi
+  # Download and unpack the stack executable
+  - mkdir -p ~/.local/bin
+  - export PATH=$HOME/.local/bin:$PATH
+  - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
-install:
- - cabal --version
- - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
- - travis_retry cabal update
- - cabal install --only-dependencies --enable-tests --enable-benchmarks
-                                                                                                    
-script:
- - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for deb    ugging
- - cabal build   # this builds all libraries and executables (including tests/benchmarks)
- - cabal test
- - cabal check
- - cabal sdist   # tests that a source-distribution can be generated
- - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
-   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+script: stack $ARGS --no-terminal --install-ghc build

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ before_install:
   - export PATH=$HOME/.local/bin:$PATH
   - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
-script: stack $ARGS --no-terminal --install-ghc build
+script: stack $ARGS --no-terminal --install-ghc test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@
 
 env:
  - ARGS=""
- - ARGS="--resolver lts"
  - ARGS="--resolver nightly"
+ - ARGS="--resolver lts"
  - ARGS="--resolver lts-8"
  - ARGS="--resolver lts-7"
  - ARGS="--resolver lts-6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
  - ARGS="--resolver nightly"
  - ARGS="--resolver lts"
  - ARGS="--resolver lts-8"
- - ARGS="--resolver lts-7"
+ - ARGS="--resolver lts-7 --ghc-options -Wno-redundant-constraints"
  - ARGS="--resolver lts-6"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
  - ARGS="--resolver nightly"
  - ARGS="--resolver lts"
  - ARGS="--resolver lts-8"
- - ARGS="--resolver lts-7 --ghc-options -Wno-redundant-constraints"
  - ARGS="--resolver lts-6"
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   owned by some user to a series of authorized clients securely. For
   instance, OAuth lets Twitter provide access to a user's private
   tweets to the Twitter client registered on their phone.
-  
+
   `oauthenticated` is a Haskell library implementing OAuth protocols
   atop the popular `http-client` HTTP client library. The goal is to
   provide a general framework for signing
@@ -16,3 +16,9 @@
   Currently `oauthenticated` only supports OAuth 1.0 and is in
   alpha. Further testing is needed before trustworthy use can be
   established. Further, OAuth 2.0 support is planned.
+
+## Example
+
+  See the `examples` directory for a script making a OAuth call to a URL
+  with default parameters. Run `stack examples/oauth-authenticate.hs
+  --help` for usage.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/tel/oauthenticated.svg?branch=master)](https://travis-ci.org/tel/oauthenticated)
+
 # Oh! Authenticated!
 
   OAuth is a popular protocol allowing servers to offer resources

--- a/examples/oauth-authenticate.hs
+++ b/examples/oauth-authenticate.hs
@@ -1,0 +1,66 @@
+#! /usr/bin/env stack
+{- stack --resolver lts-10.4 --install-ghc runghc --package classy-prelude --package http-client --package crypto-random --package oauthenticated --package uri-templater -}
+{-# OPTIONS_GHC -Wall -Werror           #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NoImplicitPrelude          #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE PackageImports             #-}
+{-# LANGUAGE QuasiQuotes                #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+
+import ClassyPrelude
+import qualified "crypto-random" Crypto.Random as Crypto
+import Data.Aeson (FromJSON, Value, eitherDecodeStrict')
+import qualified Data.ByteString.Char8 as Char8
+import qualified Network.HTTP.Client as Client
+import qualified Network.OAuth as OAuth
+import qualified Options.Applicative as Opt
+
+data Opts = Opts
+  { oauthUrl    :: String
+  , oauthKey    :: ByteString
+  , oauthSecret :: ByteString
+  }
+
+data App = App
+  { appRng     :: TVar Crypto.SystemRNG
+  , appManager :: Client.Manager
+  , appServer  :: OAuth.Server
+  , appCred    :: OAuth.Cred OAuth.Client
+  }
+
+makeRequest :: FromJSON a => App -> Client.Request -> IO a
+makeRequest App {..} req = do
+  rng <- readTVarIO appRng
+  (signedReq, newRng) <- OAuth.oauth appCred appServer req rng
+  atomically $ writeTVar appRng newRng
+  putStrLn $ tshow signedReq
+  resp <- Client.httpLbs signedReq appManager
+  putStrLn $ tshow resp
+  either (\ msg -> fail $ "Couldn't decode " <> show resp <> " due to " <> msg) pure $
+    eitherDecodeStrict' (toStrict $ Client.responseBody resp)
+
+parseArgs :: IO Opts
+parseArgs =
+  let parser = Opts
+        <$> Opt.strOption (Opt.long "oauth-url" <> Opt.help "URL")
+        <*> (Char8.pack <$> Opt.strOption (Opt.long "oauth-key" <> Opt.help "Consumer key"))
+        <*> (Char8.pack <$> Opt.strOption (Opt.long "oauth-secret" <> Opt.help "Consumer secret"))
+  in Opt.execParser $ Opt.info (Opt.helper <*> parser) (Opt.fullDesc <> Opt.progDesc "Send a test OAuth 1.0a request to a URL")
+
+main :: IO ()
+main = do
+  Opts {..} <- parseArgs
+  req <- Client.parseRequest oauthUrl
+  rng <- Crypto.cprgCreate <$> Crypto.createEntropyPool
+  rngTv <- newTVarIO rng
+  manager <- Client.newManager Client.defaultManagerSettings
+  let cred = OAuth.clientCred $ OAuth.Token oauthKey oauthSecret
+      app = App rngTv manager OAuth.defaultServer cred
+  _ :: Value <- makeRequest app req
+  pure ()

--- a/oauthenticated.cabal
+++ b/oauthenticated.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 32a52e0b20beac3ece0da25c5f01e324fd51005766afed12e9d4a1d0a94cf4d5
+-- hash: 2b92ef5e48fb8555a15a1dbc375ba963131cabd562006cd071b843ae09a5fd59
 
 name:           oauthenticated
 version:        0.2.0.0
@@ -62,7 +62,6 @@ library
     , case-insensitive
     , crypto-random
     , cryptohash
-    , either
     , exceptions
     , http-client
     , http-types

--- a/oauthenticated.cabal
+++ b/oauthenticated.cabal
@@ -1,87 +1,85 @@
-name:                oauthenticated
-version:             0.1.3.4
-synopsis:            Simple OAuth for http-client
+-- This file has been generated from package.yaml by hpack version 0.20.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 32a52e0b20beac3ece0da25c5f01e324fd51005766afed12e9d4a1d0a94cf4d5
 
-description:         
-  /Warning/: This software is pre 1.0 and thus its API may change very
-  dynamically while updating only minor versions. This package will follow the
-  PVP once it reaches version 1.0.
-  .
-  OAuth is a popular protocol allowing servers to offer resources owned by some
-  user to a series of authorized clients securely. For instance, OAuth lets
-  Twitter provide access to a user's private tweets to the Twitter client
-  registered on their phone.
-  . 
-  @oauthenticated@ is a Haskell library implementing OAuth protocols atop the
-  minimalistic @http-client@ HTTP client library extracted from @http-conduit@.
-  "Network.OAuth" offers simple functions for signing 
-  'Network.HTTP.Client.Request's along with tools for 'Network.OAuth.Cred'ential
-  management and 'Network.OAuth.Server' configuration. "Network.OAuth.Simple" 
-  provides a slightly more heavy-weight interface which manages the necessary state
-  and configuration using a monad transformer stack.
-  .
-  There's also an implementation of OAuth's three-legged credential acquisition
-  protocol built atop the "Network.OAuth" API. This can be handled in both
-  conformant and old-style modes: conformant will reject server responses which
-  are not conformant with RFC 5849 (which builds atop community version OAuth
-  1.0a) while old-style better allows for less-than-compliant servers. See
-  'Network.OAuth.Types.Params.Version' for more details.
-  .
-  Currently @oauthenticated@ only supports OAuth 1.0 and is in alpha. OAuth 2.0
-  support is a potential goal, but it's unclear if it can be transparently
-  supported at a similar level of abstraction.
-
-license:             MIT
-license-file:        LICENSE
-author:              Joseph Abrahamson
-maintainer:          me@jspha.com
-copyright:           2013 (c) Joseph Abrahamson
-category:            Network, Web
-build-type:          Simple
-cabal-version:       >=1.10
-
-flag network-uri
-  description: Get Network.URI from the network-uri package
-  default: True
-
-library
-  exposed-modules:
-    Network.OAuth
-    Network.OAuth.Simple
-    Network.OAuth.Signing
-    Network.OAuth.ThreeLegged
-    Network.OAuth.Types.Credentials
-    Network.OAuth.Types.Params
-  other-modules:
-    Network.OAuth.MuLens
-    Network.OAuth.Util
-  build-depends:       base                >= 4.6      && < 4.9
-                     , aeson               >= 0.6.2    && < 0.10
-                     , base64-bytestring   >= 1.0      && < 1.1
-                     , blaze-builder       >= 0.3
-                     , bytestring          >= 0.9
-                     , case-insensitive    >= 1.0      && < 1.3
-                     , crypto-random       >= 0.0.7
-                     , cryptohash          >= 0.11     && < 0.12
-                     , either              >= 4.0      && < 5.0
-                     , exceptions          >= 0.4
-                     , http-client         >= 0.2.0
-                     , http-types          >= 0.8
-                     , mtl                 >= 2.0
-                     , time                >= 1.2
-                     , text                >= 0.11     && < 1.3
-                     , transformers
-
-  if flag(network-uri)
-    build-depends: network-uri >= 2.6, network >= 2.6
-  else
-    build-depends: network-uri < 2.6 , network < 2.6
-
-
-  hs-source-dirs:      src         
-  ghc-options:         -Wall
-  default-language:    Haskell2010
+name:           oauthenticated
+version:        0.2.0.0
+synopsis:       Simple OAuth for http-client
+description:    /Warning/: This software is pre 1.0 and thus its API may change very
+                dynamically while updating only minor versions. This package will follow the
+                PVP once it reaches version 1.0.
+                .
+                OAuth is a popular protocol allowing servers to offer resources owned by some
+                user to a series of authorized clients securely. For instance, OAuth lets
+                Twitter provide access to a user's private tweets to the Twitter client
+                registered on their phone.
+                .
+                @oauthenticated@ is a Haskell library implementing OAuth protocols atop the
+                minimalistic @http-client@ HTTP client library extracted from @http-conduit@.
+                "Network.OAuth" offers simple functions for signing
+                'Network.HTTP.Client.Request's along with tools for 'Network.OAuth.Cred'ential
+                management and 'Network.OAuth.Server' configuration. "Network.OAuth.Simple"
+                provides a slightly more heavy-weight interface which manages the necessary state
+                and configuration using a monad transformer stack.
+                .
+                There's also an implementation of OAuth's three-legged credential acquisition
+                protocol built atop the "Network.OAuth" API. This can be handled in both
+                conformant and old-style modes: conformant will reject server responses which
+                are not conformant with RFC 5849 (which builds atop community version OAuth
+                1.0a) while old-style better allows for less-than-compliant servers. See
+                'Network.OAuth.Types.Params.Version' for more details.
+                .
+                Currently @oauthenticated@ only supports OAuth 1.0 and is in alpha. OAuth 2.0
+                support is a potential goal, but it's unclear if it can be transparently
+                supported at a similar level of abstraction.
+category:       Network, Web
+homepage:       https://github.com/tel/oauthenticated.git#readme
+bug-reports:    https://github.com/tel/oauthenticated.git/issues
+author:         Joseph Abrahamson
+maintainer:     me@jspha.com
+copyright:      2013 (c) Joseph Abrahamson
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+cabal-version:  >= 1.10
 
 source-repository head
   type: git
-  location: git://github.com/tel/oauthenticated.git
+  location: https://github.com/tel/oauthenticated.git
+
+library
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -Werror -fwarn-tabs
+  build-depends:
+      aeson
+    , base
+    , base64-bytestring
+    , blaze-builder
+    , bytestring
+    , case-insensitive
+    , crypto-random
+    , cryptohash
+    , either
+    , exceptions
+    , http-client
+    , http-types
+    , mtl
+    , network
+    , network-uri
+    , text
+    , time
+    , transformers
+  exposed-modules:
+      Network.OAuth
+      Network.OAuth.Signing
+      Network.OAuth.Simple
+      Network.OAuth.ThreeLegged
+      Network.OAuth.Types.Credentials
+      Network.OAuth.Types.Params
+  other-modules:
+      Network.OAuth.MuLens
+      Network.OAuth.Util
+  default-language: Haskell2010

--- a/oauthenticated.cabal
+++ b/oauthenticated.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2b92ef5e48fb8555a15a1dbc375ba963131cabd562006cd071b843ae09a5fd59
+-- hash: 7993a4ded63e19a2d5e4f73014128aad19325fe02142bbdcd5c99d49aa783691
 
 name:           oauthenticated
 version:        0.2.0.0
@@ -81,4 +81,38 @@ library
   other-modules:
       Network.OAuth.MuLens
       Network.OAuth.Util
+  default-language: Haskell2010
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  hs-source-dirs:
+      test
+  ghc-options: -Wall -Werror -fwarn-tabs
+  build-depends:
+      aeson
+    , base
+    , base64-bytestring
+    , blaze-builder
+    , bytestring
+    , case-insensitive
+    , crypto-random
+    , cryptohash
+    , exceptions
+    , hspec
+    , hspec-expectations
+    , http-client
+    , http-client-tls
+    , http-types
+    , mtl
+    , network
+    , network-uri
+    , oauthenticated
+    , text
+    , time
+    , transformers
+  other-modules:
+      Config
+      SigningSpec
+      Paths_oauthenticated
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -51,7 +51,6 @@ dependencies:
   - case-insensitive
   - crypto-random
   - cryptohash
-  - either
   - exceptions
   - http-client
   - http-types

--- a/package.yaml
+++ b/package.yaml
@@ -67,4 +67,15 @@ library:
     - Network.OAuth.MuLens
     - Network.OAuth.Util
 
+tests:
+  spec:
+    main: Spec.hs
+    source-dirs:
+      - test
+    dependencies:
+      - hspec
+      - hspec-expectations
+      - http-client-tls
+      - oauthenticated
+
 github: tel/oauthenticated.git

--- a/package.yaml
+++ b/package.yaml
@@ -1,0 +1,71 @@
+name: oauthenticated
+version: 0.2.0.0
+synopsis: Simple OAuth for http-client
+description: |
+  /Warning/: This software is pre 1.0 and thus its API may change very
+  dynamically while updating only minor versions. This package will follow the
+  PVP once it reaches version 1.0.
+  .
+  OAuth is a popular protocol allowing servers to offer resources owned by some
+  user to a series of authorized clients securely. For instance, OAuth lets
+  Twitter provide access to a user's private tweets to the Twitter client
+  registered on their phone.
+  .
+  @oauthenticated@ is a Haskell library implementing OAuth protocols atop the
+  minimalistic @http-client@ HTTP client library extracted from @http-conduit@.
+  "Network.OAuth" offers simple functions for signing
+  'Network.HTTP.Client.Request's along with tools for 'Network.OAuth.Cred'ential
+  management and 'Network.OAuth.Server' configuration. "Network.OAuth.Simple"
+  provides a slightly more heavy-weight interface which manages the necessary state
+  and configuration using a monad transformer stack.
+  .
+  There's also an implementation of OAuth's three-legged credential acquisition
+  protocol built atop the "Network.OAuth" API. This can be handled in both
+  conformant and old-style modes: conformant will reject server responses which
+  are not conformant with RFC 5849 (which builds atop community version OAuth
+  1.0a) while old-style better allows for less-than-compliant servers. See
+  'Network.OAuth.Types.Params.Version' for more details.
+  .
+  Currently @oauthenticated@ only supports OAuth 1.0 and is in alpha. OAuth 2.0
+  support is a potential goal, but it's unclear if it can be transparently
+  supported at a similar level of abstraction.
+license: MIT
+license-file: LICENSE
+author: Joseph Abrahamson
+maintainer: me@jspha.com
+copyright: 2013 (c) Joseph Abrahamson
+category: Network, Web
+build-type: Simple
+
+ghc-options:
+  - -Wall
+  - -Werror
+  - -fwarn-tabs
+
+dependencies:
+  - base
+  - aeson
+  - base64-bytestring
+  - blaze-builder
+  - bytestring
+  - case-insensitive
+  - crypto-random
+  - cryptohash
+  - either
+  - exceptions
+  - http-client
+  - http-types
+  - mtl
+  - time
+  - text
+  - transformers
+  - network-uri
+  - network
+
+library:
+  source-dirs: src
+  other-modules:
+    - Network.OAuth.MuLens
+    - Network.OAuth.Util
+
+github: tel/oauthenticated.git

--- a/src/Network/OAuth/MuLens.hs
+++ b/src/Network/OAuth/MuLens.hs
@@ -21,7 +21,6 @@ module Network.OAuth.MuLens (
   (<&>), (&), (^.), (.~), (%~),
   ) where
 
-import           Control.Applicative
 import           Data.Functor.Identity
 import           Data.Functor.Constant
 

--- a/src/Network/OAuth/Signing.hs
+++ b/src/Network/OAuth/Signing.hs
@@ -142,6 +142,16 @@ oauthParams (Oa {..}) (Server {..}) =
     infix 8 -:
     s -: v = (s, H.toQueryValue v)
 
+    -- **NOTE** dfithian: It worked for my use case to move oauth_token into these params. From the
+    -- PR:
+    --
+    -- I presume one very controversial thing I did was to move `oauth_token` into `workflowParams`.
+    -- I came to this conclusion by skimming through the [RFC](https://tools.ietf.org/html/rfc5849)
+    -- and deciding that since I only ever saw `oauth_token` in conjunction with either
+    -- `oauth_callback` or `oauth_verifier` that they should go together. I'd be perfectly happy to
+    -- instead pass in some function of the settings telling it whether or not to include
+    -- `oauth_token` for a given request. Whatever the conclusion, the service I'm integrating to
+    -- specifically does NOT want the `oauth_token` so that was the motivation.
     workflowParams Standard = []
     workflowParams (TemporaryTokenRequest callback) =
       [ "oauth_callback" -: callback

--- a/src/Network/OAuth/Types/Credentials.hs
+++ b/src/Network/OAuth/Types/Credentials.hs
@@ -1,7 +1,4 @@
-#if __GLASGOW_HASKELL__==800
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
-#endif
-{-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints -fno-warn-incomplete-patterns #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings  #-}
 

--- a/src/Network/OAuth/Types/Credentials.hs
+++ b/src/Network/OAuth/Types/Credentials.hs
@@ -1,3 +1,6 @@
+#if __GLASGOW_HASKELL__==800
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+#endif
 {-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings  #-}

--- a/src/Network/OAuth/Types/Credentials.hs
+++ b/src/Network/OAuth/Types/Credentials.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -Wno-redundant-constraints -fno-warn-incomplete-patterns #-}
+{-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings  #-}
 

--- a/src/Network/OAuth/Types/Params.hs
+++ b/src/Network/OAuth/Types/Params.hs
@@ -19,7 +19,6 @@
 
 module Network.OAuth.Types.Params where
 
-import           Control.Applicative
 import           Crypto.Random
 import qualified Data.ByteString                 as S
 import qualified Data.ByteString.Base64          as S64

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+resolver: lts-10.4
+packages:
+  - .
+flags: {}
+extra-package-dbs: []

--- a/test/Config.hs
+++ b/test/Config.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+
+module Config where
+
+import Crypto.Random (SystemRNG, cprgCreate, createEntropyPool)
+import Network.HTTP.Client (Manager, newManager)
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.OAuth (Client, Cred, Server, Token (Token), clientCred, defaultServer)
+
+data Config = Config
+  { rng  :: SystemRNG
+  , man  :: Manager
+  , ser  :: Server
+  , cred :: Cred Client
+  , url  :: String
+  }
+
+loadConfig :: IO Config
+loadConfig = do
+  -- these are on the public internet so they're okay
+  let cred = clientCred $ Token "RKCGzna7bv9YD57c" "D+EdQ-gs$-%@2Nu7"
+      url = "https://postman-echo.com/oauth1"
+      ser = defaultServer
+  rng <- cprgCreate <$> createEntropyPool
+  man <- newManager tlsManagerSettings
+  pure $ Config {..}

--- a/test/SigningSpec.hs
+++ b/test/SigningSpec.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module SigningSpec where
+
+import Control.Monad
+import Network.HTTP.Client (httpLbs, parseRequest, responseStatus)
+import Network.HTTP.Types (status200)
+import Network.OAuth (oauth)
+import Test.Hspec (Spec, describe, example, it)
+import Test.Hspec.Expectations (shouldBe)
+
+import Config (Config (Config, cred, man, rng, ser, url))
+
+spec :: Config -> Spec
+spec Config {..} = describe "signing" $ do
+  it "authorizes a request" $ do
+    req <- parseRequest url
+    (signedReq, _) <- oauth cred ser req rng
+    resp <- httpLbs signedReq man
+    responseStatus resp `shouldBe` status200
+
+  it "authorizes many requests" $ do
+    req <- parseRequest url
+    (_, resps) <- foldM (\ (gen, acc) next -> do
+                            (signedReq, newGen) <- oauth cred ser next gen
+                            resp <- httpLbs signedReq man
+                            pure (newGen, resp:acc)
+                        ) (rng, []) (replicate 100 req)
+    forM_ resps $ \ resp ->
+      example $ responseStatus resp `shouldBe` status200

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,10 @@
+import Test.Hspec (hspec)
+
+import Config (loadConfig)
+import qualified SigningSpec
+
+main :: IO ()
+main = do
+  config <- loadConfig
+  hspec $ do
+    SigningSpec.spec config


### PR DESCRIPTION
Uses stack + hpack

I presume one very controversial thing I did was to move `oauth_token` into `workflowParams`. I came to this conclusion by skimming through the [RFC](https://tools.ietf.org/html/rfc5849) and deciding that since I only ever saw `oauth_token` in conjunction with either `oauth_callback` or `oauth_verifier` that they should go together. I'd be perfectly happy to instead pass in some function of the settings telling it whether or not to include `oauth_token` for a given request. Whatever the conclusion, the service I'm integrating to specifically does **NOT** want the `oauth_token` so that was the motivation.

Another thing that travis did was call `cabal test` but since there are no tests I made this just `stack build`.

@mossprescott @ystael