### PR TITLE
Switch to cryptonite and MonadRandom

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,8 @@
   See the `examples` directory for a script making a OAuth call to a URL
   with default parameters. Run `stack examples/oauth-authenticate.hs
   --help` for usage.
+
+## Three-legged Protocol
+
+  Warning: the implementation in ThreeLegged.hs has not been tested since recent
+  refactoring and may or may not do anything useful.

--- a/oauthenticated.cabal
+++ b/oauthenticated.cabal
@@ -2,10 +2,10 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 655614165ca559bb85ecc1850b8c1f90ec9de4ab3491d277b259a302a2790ab3
+-- hash: 57f362363e0372f8ed826839dd46a943056dacf5c94980d89d3443c4de1a4ab4
 
 name:           oauthenticated
-version:        0.2.0.0
+version:        0.2.1.0
 synopsis:       Simple OAuth for http-client
 description:    /Warning/: This software is pre 1.0 and thus its API may change very
                 dynamically while updating only minor versions. This package will follow the

--- a/oauthenticated.cabal
+++ b/oauthenticated.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 17b79e47a3f7b1729531b411a7a3e56766102b8aeb5e6ba09cdabd55c17d5d88
+-- hash: 655614165ca559bb85ecc1850b8c1f90ec9de4ab3491d277b259a302a2790ab3
 
 name:           oauthenticated
 version:        0.2.0.0
@@ -52,19 +52,19 @@ source-repository head
 library
   hs-source-dirs:
       src
-  ghc-options: -Wall -fwarn-tabs
+  ghc-options: -Wall -Werror -fwarn-tabs
   build-depends:
       aeson
-    , base >=4.10 && <5
+    , base >=4.8 && <5
     , base64-bytestring
     , blaze-builder
     , bytestring
     , case-insensitive
-    , crypto-random
-    , cryptohash
+    , cryptonite
     , exceptions
     , http-client
     , http-types
+    , memory
     , mtl
     , network
     , network-uri
@@ -88,22 +88,22 @@ test-suite spec
   main-is: Spec.hs
   hs-source-dirs:
       test
-  ghc-options: -Wall -fwarn-tabs
+  ghc-options: -Wall -Werror -fwarn-tabs
   build-depends:
       aeson
-    , base >=4.10 && <5
+    , base >=4.8 && <5
     , base64-bytestring
     , blaze-builder
     , bytestring
     , case-insensitive
-    , crypto-random
-    , cryptohash
+    , cryptonite
     , exceptions
     , hspec
     , hspec-expectations
     , http-client
     , http-client-tls
     , http-types
+    , memory
     , mtl
     , network
     , network-uri

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: oauthenticated
-version: 0.2.0.0
+version: 0.2.1.0
 synopsis: Simple OAuth for http-client
 description: |
   /Warning/: This software is pre 1.0 and thus its API may change very

--- a/package.yaml
+++ b/package.yaml
@@ -39,7 +39,7 @@ build-type: Simple
 
 ghc-options:
   - -Wall
-  # - -Werror
+  - -Werror
   - -fwarn-tabs
 
 dependencies:
@@ -49,11 +49,11 @@ dependencies:
   - blaze-builder
   - bytestring
   - case-insensitive
-  - crypto-random
-  - cryptohash
+  - cryptonite
   - exceptions
   - http-client
   - http-types
+  - memory
   - mtl
   - time
   - text

--- a/src/Network/OAuth.hs
+++ b/src/Network/OAuth.hs
@@ -38,14 +38,14 @@ module Network.OAuth (
   -- a fresh set of 'O.Oa' parameters from a relevant or deterministic
   -- 'O.OaPin' and then using 'S.sign' to sign the 'C.Request'.
   S.sign,
-  
+
   -- ** Generating OAuth parameters
-  O.emptyOa, O.freshOa, O.emptyPin, O.freshPin, 
+  O.emptyOa, O.freshOa, O.emptyPin, O.freshPin,
 
   -- * OAuth Credentials
   O.Token (..), O.Cred, O.Client, O.Temporary, O.Permanent,
 
-  -- ** Creating Credentials  
+  -- ** Creating Credentials
   O.clientCred, O.temporaryCred, O.permanentCred,
   O.fromUrlEncoded,
 
@@ -55,18 +55,14 @@ module Network.OAuth (
 
   ) where
 
-import qualified Crypto.Random                   as R
 import qualified Network.HTTP.Client             as C
 import qualified Network.OAuth.Signing           as S
 import qualified Network.OAuth.Types.Credentials as O
 import qualified Network.OAuth.Types.Params      as O
 
--- | Sign a request with a fresh set of parameters. Creates a fresh
--- 'R.SystemRNG' using new entropy for each signing and thus is potentially
--- /dangerous/ if used too frequently. In almost all cases, 'S.oauth'
--- should be used instead.
+-- | Sign a request with a fresh set of parameters. Uses @MonadRandom IO@, getting
+-- new entropy for each signing and thus is potentially /dangerous/ if used too
+-- frequently. In almost all cases, 'S.oauth' should be used instead with a suitably
+-- seeded PRNG.
 oauthSimple :: O.Cred ty -> O.Server -> C.Request -> IO C.Request
-oauthSimple cr srv req = do
-  entropy   <- R.createEntropyPool
-  (req', _) <- S.oauth cr srv req (R.cprgCreate entropy :: R.SystemRNG)
-  return req'
+oauthSimple = S.oauth

--- a/src/Network/OAuth/ThreeLegged.hs
+++ b/src/Network/OAuth/ThreeLegged.hs
@@ -30,7 +30,8 @@ module Network.OAuth.ThreeLegged (
   requestTokenProtocol, requestTokenProtocol'
   ) where
 
-import qualified Crypto.Random                   as R
+import           Control.Monad.IO.Class          (MonadIO, liftIO)
+import           Crypto.Random                   (MonadRandom)
 import qualified Data.ByteString.Lazy            as SL
 import           Data.Data
 import qualified Network.HTTP.Client             as C
@@ -87,14 +88,13 @@ parseThreeLegged a b c d =
 --
 -- Throws 'C.HttpException's.
 requestTemporaryTokenRaw
-  :: R.CPRG gen => O.Cred O.Client -> O.Server
-                -> ThreeLegged -> C.Manager -> gen
-                -> IO (C.Response SL.ByteString, gen)
-requestTemporaryTokenRaw cr srv (ThreeLegged {..}) man gen = do
-  (oax, gen') <- O.freshOa cr gen
+  :: (MonadIO m, MonadRandom m) => O.Cred O.Client -> O.Server
+                                -> ThreeLegged -> C.Manager
+                                -> m(C.Response SL.ByteString)
+requestTemporaryTokenRaw cr srv (ThreeLegged {..}) man = do
+  oax <- O.freshOa cr
   let req = O.sign (oax { P.workflow = P.TemporaryTokenRequest callback }) srv temporaryTokenRequest
-  lbs <- C.httpLbs req man
-  return (lbs, gen')
+  liftIO $ C.httpLbs req man
 
 -- | Returns the raw result if the 'C.Response' could not be parsed as
 -- a valid 'O.Token'.  Importantly, in RFC 5849 compliant modes this
@@ -103,12 +103,12 @@ requestTemporaryTokenRaw cr srv (ThreeLegged {..}) man gen = do
 --
 -- Throws 'C.HttpException's.
 requestTemporaryToken
-  :: R.CPRG gen => O.Cred O.Client -> O.Server
-                -> ThreeLegged -> C.Manager -> gen
-                -> IO (C.Response (Either SL.ByteString (O.Token O.Temporary)), gen)
-requestTemporaryToken cr srv tl man gen = do
-  (raw, gen') <- requestTemporaryTokenRaw cr srv tl man gen
-  return (tryParseToken <$> raw, gen')
+  :: (MonadIO m, MonadRandom m) => O.Cred O.Client -> O.Server
+                                -> ThreeLegged -> C.Manager
+                                -> m (C.Response (Either SL.ByteString (O.Token O.Temporary)))
+requestTemporaryToken cr srv tl man = do
+  raw <- requestTemporaryTokenRaw cr srv tl man
+  return $ tryParseToken <$> raw
   where
     tryParseToken lbs = case maybeParseToken lbs of
       Nothing  -> Left lbs
@@ -133,28 +133,27 @@ buildAuthorizationUrl cr (ThreeLegged {..}) =
 --
 -- Throws 'C.HttpException's.
 requestPermanentTokenRaw
-  :: R.CPRG gen => O.Cred O.Temporary -> O.Server
-                -> P.Verifier
-                -> ThreeLegged -> C.Manager -> gen
-                -> IO (C.Response SL.ByteString, gen)
-requestPermanentTokenRaw cr srv verifier (ThreeLegged {..}) man gen = do
-  (oax, gen') <- O.freshOa cr gen
+  :: (MonadIO m, MonadRandom m) => O.Cred O.Temporary -> O.Server
+                                -> P.Verifier
+                                -> ThreeLegged -> C.Manager
+                                -> m (C.Response SL.ByteString)
+requestPermanentTokenRaw cr srv verifier (ThreeLegged {..}) man = do
+  oax <- O.freshOa cr
   let req = O.sign (oax { P.workflow = P.PermanentTokenRequest verifier }) srv permanentTokenRequest
-  lbs <- C.httpLbs req man
-  return (lbs, gen')
+  liftIO $ C.httpLbs req man
 
 -- | Returns 'Nothing' if the response could not be decoded as a 'Token'.
 -- See also 'requestPermanentTokenRaw'.
 --
 -- Throws 'C.HttpException's.
-requestPermanentToken 
-  :: R.CPRG gen => O.Cred O.Temporary -> O.Server
-                -> P.Verifier
-                -> ThreeLegged -> C.Manager -> gen
-                -> IO (C.Response (Either SL.ByteString (O.Token O.Permanent)), gen)
-requestPermanentToken cr srv verifier tl man gen = do
-  (raw, gen') <- requestPermanentTokenRaw cr srv verifier tl man gen
-  return (tryParseToken <$> raw, gen')
+requestPermanentToken
+  :: (MonadIO m, MonadRandom m) => O.Cred O.Temporary -> O.Server
+                                -> P.Verifier
+                                -> ThreeLegged -> C.Manager
+                                -> m (C.Response (Either SL.ByteString (O.Token O.Permanent)))
+requestPermanentToken cr srv verifier tl man = do
+  raw <- requestPermanentTokenRaw cr srv verifier tl man
+  return $ tryParseToken <$> raw
   where
     tryParseToken lbs = case maybeParseToken lbs of
       Nothing  -> Left lbs
@@ -163,21 +162,19 @@ requestPermanentToken cr srv verifier tl man gen = do
 
 -- | Like 'requestTokenProtocol' but allows for specification of the
 -- 'C.ManagerSettings'.
-requestTokenProtocol' 
-  :: C.ManagerSettings -> O.Cred O.Client -> O.Server -> ThreeLegged 
-     -> (URI -> IO P.Verifier) 
-     -> IO (Maybe (O.Cred O.Permanent))
+requestTokenProtocol'
+  :: (MonadIO m, MonadRandom m) => C.ManagerSettings -> O.Cred O.Client -> O.Server -> ThreeLegged
+                                -> (URI -> m P.Verifier)
+                                -> m (Maybe (O.Cred O.Permanent))
 requestTokenProtocol' mset cr srv tl getVerifier = do
-  entropy <- R.createEntropyPool
-  man <- C.newManager mset
-  let gen = (R.cprgCreate entropy :: R.SystemRNG)
-  (respTempToken, gen') <- requestTemporaryToken cr srv tl man gen 
+  man <- liftIO $ C.newManager mset
+  respTempToken <- requestTemporaryToken cr srv tl man
   case C.responseBody respTempToken of
     Left _ -> return Nothing
     Right tok -> do
       let tempCr = O.temporaryCred tok cr
       verifier <- getVerifier $ buildAuthorizationUrl tempCr tl
-      (respPermToken, _) <- requestPermanentToken tempCr srv verifier tl man gen'
+      respPermToken <- requestPermanentToken tempCr srv verifier tl man
       case C.responseBody respPermToken of
         Left _ -> return Nothing
         Right tok' -> return (Just $ O.permanentCred tok' cr)
@@ -188,10 +185,10 @@ requestTokenProtocol' mset cr srv tl getVerifier = do
 -- will throw a 'C.TlsNotSupported' exception if TLS is required.
 --
 -- Throws 'C.HttpException's.
-requestTokenProtocol 
-  :: O.Cred O.Client -> O.Server -> ThreeLegged 
-     -> (URI -> IO P.Verifier) 
-     -> IO (Maybe (O.Cred O.Permanent))
+requestTokenProtocol
+  :: (MonadIO m, MonadRandom m) => O.Cred O.Client -> O.Server -> ThreeLegged
+                                -> (URI -> m P.Verifier)
+                                -> m (Maybe (O.Cred O.Permanent))
 requestTokenProtocol = requestTokenProtocol' C.defaultManagerSettings
 
 

--- a/test/Config.hs
+++ b/test/Config.hs
@@ -3,14 +3,12 @@
 
 module Config where
 
-import Crypto.Random (SystemRNG, cprgCreate, createEntropyPool)
 import Network.HTTP.Client (Manager, newManager)
 import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Network.OAuth (Client, Cred, Server, Token (Token), clientCred, defaultServer)
 
 data Config = Config
-  { rng  :: SystemRNG
-  , man  :: Manager
+  { man  :: Manager
   , ser  :: Server
   , cred :: Cred Client
   , url  :: String
@@ -22,6 +20,5 @@ loadConfig = do
   let cred = clientCred $ Token "RKCGzna7bv9YD57c" "D+EdQ-gs$-%@2Nu7"
       url = "https://postman-echo.com/oauth1"
       ser = defaultServer
-  rng <- cprgCreate <$> createEntropyPool
   man <- newManager tlsManagerSettings
   pure $ Config {..}

--- a/test/SigningSpec.hs
+++ b/test/SigningSpec.hs
@@ -3,7 +3,8 @@
 module SigningSpec where
 
 import Control.Monad
-import Network.HTTP.Client (httpLbs, parseRequest, responseStatus)
+import Data.List (nub)
+import Network.HTTP.Client (httpLbs, parseRequest, requestHeaders, responseStatus)
 import Network.HTTP.Types (status200)
 import Network.OAuth (oauth)
 import Test.Hspec (Spec, describe, example, it)
@@ -28,3 +29,9 @@ spec Config {..} = describe "signing" $ do
                         ) [] (replicate 100 req)
     forM_ resps $ \ resp ->
       example $ responseStatus resp `shouldBe` status200
+
+  it "generates a unique nonce for each repeated request" $ do
+    req <- parseRequest url
+    headers <- replicateM 100 (requestHeaders <$> oauth cred ser req)
+    let uniqueHeaders = nub headers
+    length headers `shouldBe` length uniqueHeaders

--- a/test/SigningSpec.hs
+++ b/test/SigningSpec.hs
@@ -9,22 +9,22 @@ import Network.OAuth (oauth)
 import Test.Hspec (Spec, describe, example, it)
 import Test.Hspec.Expectations (shouldBe)
 
-import Config (Config (Config, cred, man, rng, ser, url))
+import Config (Config (Config, cred, man, ser, url))
 
 spec :: Config -> Spec
 spec Config {..} = describe "signing" $ do
   it "authorizes a request" $ do
     req <- parseRequest url
-    (signedReq, _) <- oauth cred ser req rng
+    signedReq <- oauth cred ser req
     resp <- httpLbs signedReq man
     responseStatus resp `shouldBe` status200
 
   it "authorizes many requests" $ do
     req <- parseRequest url
-    (_, resps) <- foldM (\ (gen, acc) next -> do
-                            (signedReq, newGen) <- oauth cred ser next gen
+    resps <- foldM (\ acc next -> do
+                            signedReq <- oauth cred ser next
                             resp <- httpLbs signedReq man
-                            pure (newGen, resp:acc)
-                        ) (rng, []) (replicate 100 req)
+                            pure $ resp:acc
+                        ) [] (replicate 100 req)
     forM_ resps $ \ resp ->
       example $ responseStatus resp `shouldBe` status200


### PR DESCRIPTION
This was motivated by what appeared to be a bug in crypto-random that led to duplicate nonces being generated. 

Switching to MonadRandom significantly cleans up the code and also gives some additional flexibility in where the randomness comes from.

Note: this essentially recapitulates PRs #16 and #17 against the current state. I will comment on a couple of spots where this differs from those PRs.