### PR TITLE
Support HMAC-SHA256 signing method

### DIFF
--- a/src/Network/OAuth/Signing.hs
+++ b/src/Network/OAuth/Signing.hs
@@ -37,7 +37,7 @@ module Network.OAuth.Signing (
 
 import qualified Blaze.ByteString.Builder        as Blz
 import           Control.Monad.IO.Class          (MonadIO)
-import           Crypto.Hash                     (SHA1)
+import           Crypto.Hash                     (SHA1, SHA256)
 import           Crypto.Random                   (MonadRandom)
 import           Crypto.MAC.HMAC                 (HMAC, hmac)
 import           Data.ByteArray                  (convert)
@@ -74,8 +74,9 @@ sign oax server req =
   in augmentRequest (parameterMethod server) params req
 
 makeSignature :: SignatureMethod -> S.ByteString -> S.ByteString -> S.ByteString
-makeSignature HmacSha1  sigKey payload = S64.encode $ convert (hmac sigKey payload :: HMAC SHA1)
-makeSignature Plaintext sigKey _       = sigKey
+makeSignature HmacSha1    sigKey payload = S64.encode $ convert (hmac sigKey payload :: HMAC SHA1)
+makeSignature HmacSha256  sigKey payload = S64.encode $ convert (hmac sigKey payload :: HMAC SHA256)
+makeSignature Plaintext   sigKey _       = sigKey
 
 -- | Augments whatever component of the 'C.Request' is specified by
 -- 'ParameterMethod' with one built from the apropriate OAuth parameters

--- a/src/Network/OAuth/Types/Params.hs
+++ b/src/Network/OAuth/Types/Params.hs
@@ -57,12 +57,14 @@ data ParameterMethod = AuthorizationHeader
 -- Several methods exist for generating these signatures, the most
 -- popular being 'HmacSha1'.
 data SignatureMethod = HmacSha1
+                     | HmacSha256
                      | Plaintext
                      deriving ( Show, Eq, Ord, Data, Typeable )
 
 instance H.QueryValueLike SignatureMethod where
-  toQueryValue HmacSha1  = Just "HMAC-SHA1"
-  toQueryValue Plaintext = Just "PLAINTEXT"
+  toQueryValue HmacSha1    = Just "HMAC-SHA1"
+  toQueryValue HmacSha256  = Just "HMAC-SHA256"
+  toQueryValue Plaintext   = Just "PLAINTEXT"
 
 -- | OAuth has progressed through several versions since its inception. In
 -- particular, there are two community editions \"OAuth Core 1.0\" (2007)


### PR DESCRIPTION
HMAC-SHA256 is not technically required by the OAuth spec. However it is
a very common signing method across many implementations.

> The protocol defines three signature methods: HMAC-SHA1, RSA-SHA1, and
> PLAINTEXT, but Service Providers are free to implement and document
> their own methods.
>
> https://oauth.net/core/1.0/#signing_process

This commit:

- Exposes `HmacSha256` as a value in the `SignatureMethod`.
- Supports `HmacSha256` within `makeSignature` via `Crypto.Hash.SHA256`.
- Encodes `HmacSha256` as `"HMAC-SHA256"` via `QueryValueLike`.